### PR TITLE
Make script return child process status code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+
+#IntelliJ
+.idea

--- a/bin/with-package.js
+++ b/bin/with-package.js
@@ -69,5 +69,6 @@ proc.stderr.on('data', function (chunk) {
 
 proc.on('close', function (code) {
   log('child process exited with code ' + code);
+  process.exitCode = code;
 });
 


### PR DESCRIPTION
I found a problem when running 'docker image build' - sript always returns 0, no matter what the result of the build was. Setting exitCode to child proces exitCode fix this problem.